### PR TITLE
reconfigured log group config to be wide open on create, but only man…

### DIFF
--- a/terraform/modules/iam/templates/github_oidc_roles/write_permissions/gh_ci_eks_write.json.tpl
+++ b/terraform/modules/iam/templates/github_oidc_roles/write_permissions/gh_ci_eks_write.json.tpl
@@ -49,10 +49,17 @@
             "Resource": "${WRITE_ROLE_ARN}"
         },
         {
+            "Sid": "LogsCreateGroupForCluster",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup"
+            ],
+            "Resource": "*"
+        },
+        {
             "Sid": "LogsManageOnlyThisClusterGroup",
             "Effect": "Allow",
             "Action": [
-                "logs:CreateLogGroup",
                 "logs:DeleteLogGroup",
                 "logs:TagResource",
                 "logs:PutRetentionPolicy"


### PR DESCRIPTION
…age via this cluster

<type>(<scope>): <summary>

- Why this change is needed
- What areas are impacted