### PR TITLE
fix(bootstrap): ensure kustomize is installed into /usr/local/bin and…

### DIFF
--- a/terraform/modules/bastion/main.tf
+++ b/terraform/modules/bastion/main.tf
@@ -172,7 +172,7 @@ locals {
     set -euo pipefail
 
     # cloud-init can run with HOME unset when set -u is on
-    : "${HOME:=/root}"
+    : "$${HOME:=/root}"
 
     # ensure PATH has /usr/local/bin early so kustomize works right away
     export PATH="/usr/local/bin:/usr/sbin:/sbin:/usr/bin:/bin:$PATH"

--- a/terraform/modules/bastion/main.tf
+++ b/terraform/modules/bastion/main.tf
@@ -171,6 +171,16 @@ locals {
     #!/bin/bash
     set -euo pipefail
 
+    # cloud-init can run with HOME unset when set -u is on
+    : "${HOME:=/root}"
+
+    # ensure PATH has /usr/local/bin early so kustomize works right away
+    export PATH="/usr/local/bin:/usr/sbin:/sbin:/usr/bin:/bin:$PATH"
+
+    # persist PATH for future shells
+    echo 'export PATH="/usr/local/bin:$PATH"' >/etc/profile.d/00-localbin.sh
+    chmod 0644 /etc/profile.d/00-localbin.sh
+
     # Terraform-injected vars
     REGION="${var.region}"
     CLUSTER="${var.cluster_name}"

--- a/terraform/modules/bastion/scripts/bootstrap.sh
+++ b/terraform/modules/bastion/scripts/bootstrap.sh
@@ -46,19 +46,8 @@ echo "Downloading: $URL"
 curl -fsSL "$URL" -o "$TMPD/kustomize.tgz"
 tar -xzf "$TMPD/kustomize.tgz" -C "$TMPD"
 
-# ensure ~/.local/bin exists
-BIN_DIR="$HOME/.local/bin"
-mkdir -p "$BIN_DIR"
-install -m 0755 "$TMPD/kustomize" "$BIN_DIR/kustomize"
-
-# add ~/.local/bin to PATH if not already
-case ":${PATH}:" in
-  *":${BIN_DIR}:"*) : ;;  # already in PATH
-  *)
-    echo "export PATH=\"${BIN_DIR}:$PATH\"" >> "$HOME/.bashrc"
-    export PATH="${BIN_DIR}:$PATH"
-    ;;
-esac
+# install into /usr/local/bin (already in PATH)
+install -m 0755 "$TMPD/kustomize" /usr/local/bin/kustomize
 
 kustomize version || true
 


### PR DESCRIPTION
… available via user_data PATH

<type>(<scope>): <summary>

- Why this change is needed
- What areas are impacted